### PR TITLE
Update  mysql_crud.php

### DIFF
--- a/class/mysql_crud.php
+++ b/class/mysql_crud.php
@@ -141,6 +141,7 @@ class Database{
     	// Check to see if the table exists
     	 if($this->tableExists($table)){
     	 	$sql='INSERT INTO `'.$table.'` (`'.implode('`, `',array_keys($params)).'`) VALUES ("' . implode('", "', $params) . '")';
+		 $sql = str_replace('""', 'NULL', $sql); // Replace empty string with NULL
             $this->myQuery = $sql; // Pass back the SQL
             // Make the query to insert to the database
             if($ins = $this->myconn->query($sql)){


### PR DESCRIPTION
Updated `insert()` function. Inserting fails when your table has columns like `INT (Default NULL)` or `DOUBLE (Default NULL)`. Because it converts null values into empty string (`""`) when you join array of insert parameters with `implode()` function. And MySQL does not allow to insert empty string to numeric fields. It's not problem for `VARCHAR` or `TEXT` fields. So empty strings need to be replaced with null in SQL query.